### PR TITLE
Retract hnslib version v0.0.15.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,3 +10,7 @@ require (
 )
 
 require github.com/stretchr/testify v1.9.0 // indirect
+
+retract (
+    v0.0.15 // Retract v0.0.15 because it's not a valid version
+)


### PR DESCRIPTION
v0.0.15 version of hnslib published as part of https://proxy.golang.org/github.com/Microsoft/hnslib repository is not a valid hnslib version. It's also listed in go versions.

go list -m -versions -mod=mod github.com/Microsoft/hnslib
github.com/Microsoft/hnslib v0.0.1 v0.0.2 v0.0.3 v0.0.4 v0.0.5 v0.0.6 v0.0.7 v0.0.8 v0.0.9 v0.0.15

The code changes are added to exclude v0.0.15 from the go get -u list.

