### PR TITLE
Added flags field to Network Subnets

### DIFF
--- a/hcn/hcnnetwork.go
+++ b/hcn/hcnnetwork.go
@@ -11,6 +11,15 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// SubnetFlags represents the flags that can be set on a subnet
+type SubnetFlags uint32
+
+// SubnetFlags constants (based on HNS API documentation)
+const (
+	SubnetFlagsNone                       SubnetFlags = 0
+	SubnetFlagsDoNotReserveGatewayAddress SubnetFlags = 1 // This flag is needed to support scenario  GatewayAddress == ManagementIP
+)
+
 // Route is associated with a subnet.
 type Route struct {
 	NextHop           string `json:",omitempty"`
@@ -23,6 +32,7 @@ type Subnet struct {
 	IpAddressPrefix string            `json:",omitempty"`
 	Policies        []json.RawMessage `json:",omitempty"`
 	Routes          []Route           `json:",omitempty"`
+	Flags           SubnetFlags       `json:",omitempty"`
 }
 
 // Ipam (Internet Protocol Address Management) is associated with a network


### PR DESCRIPTION
Subnets have a flags field that is needed to fix issue for network rehydration when GatewayAddress == ManagementIP. 

Customers need to be able to use the Flag "DoNotReserveGatewayAddress" in order to support rehydration for the above scenario.